### PR TITLE
Remove site navigation

### DIFF
--- a/_includes/header.html
+++ b/_includes/header.html
@@ -12,14 +12,6 @@
           <path fill="#424242" d="M18,13.516C18,14.335,17.335,15,16.516,15H1.484C0.665,15,0,14.335,0,13.516l0,0 c0-0.82,0.665-1.484,1.484-1.484h15.031C17.335,12.031,18,12.696,18,13.516L18,13.516z"/>
         </svg>
       </a>
-
-      <div class="trigger">
-        {% for page in site.pages %}
-          {% if page.title %}
-          <a class="page-link" href="{{ page.url | prepend: site.baseurl }}">{{ page.title }}</a>
-          {% endif %}
-        {% endfor %}
-      </div>
     </nav>
 
   </div>


### PR DESCRIPTION
The navigation menu had just one target: the home page itself. Therefore lets's remove it, since the floating link on the upper right is confusing.